### PR TITLE
Change .so target to match plugin name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-all: client server gsttimestampoverlay.so
+all: client server libgsttimeoverlayparse.so
 
 CFLAGS?=-Wall -Werror -O2
 
-gsttimestampoverlay.so : \
+libgsttimeoverlayparse.so : \
         gsttimestampoverlay.c \
         gsttimestampoverlay.h \
         gsttimeoverlayparse.c \


### PR DESCRIPTION
From https://gstreamer.freedesktop.org/releases/1.14/

The default plugin entry point has changed. This will only affect plugins that are recompiled against new GStreamer headers. Binary plugins using the old entry point will continue to work. However, plugins that are recompiled must have matching plugin names in GST_PLUGIN_DEFINE and filenames, as the plugin entry point for shared plugins is now deduced from the plugin filename. This means you can no longer have a plugin called foo living in a file called libfoobar.so or such, the plugin filename needs to match. This might cause problems with some external third party plugin modules when they get rebuilt against GStreamer 1.14