### PR TITLE
use same clock reference for overlay and parser

### DIFF
--- a/gsttimestampoverlay.c
+++ b/gsttimestampoverlay.c
@@ -223,10 +223,7 @@ gst_timestampoverlay_transform_frame_ip (GstVideoFilter * filter, GstVideoFrame 
   else
     render_time = clock_time;
 
-  GST_OBJECT_LOCK (overlay->realtime_clock);
-  render_realtime = gst_clock_unadjust_unlocked (
-      overlay->realtime_clock, render_time);
-  GST_OBJECT_UNLOCK (overlay->realtime_clock);
+  render_realtime = render_time;
 
   imgdata = frame->data[0];
 


### PR DESCRIPTION
because `gst_clock_set_calibration ()` will not be called by the present code, `gst_clock_unadjust_unlocked ()` returns unexpected values.

i don't know, if you can accept this very simple fix, but it simply tries to use the same clock source in the overlay module and the parser. this seems to work in my basic gstreamer experiments. 

Fixes: #6